### PR TITLE
Prevent build problems on some systems

### DIFF
--- a/compile_leveldb.sh
+++ b/compile_leveldb.sh
@@ -10,6 +10,7 @@ set -e;
 
 (
     cd py-leveldb
+    rm -rf build
     python setup.py build
 )
 

--- a/py-leveldb/leveldb/build_detect_platform
+++ b/py-leveldb/leveldb/build_detect_platform
@@ -183,17 +183,6 @@ EOF
         COMMON_FLAGS="$COMMON_FLAGS -DLEVELDB_PLATFORM_POSIX"
     fi
 
-    # Test whether Snappy library is installed
-    # http://code.google.com/p/snappy/
-    $CXX $CXXFLAGS -x c++ - -o $CXXOUTPUT 2>/dev/null  <<EOF
-      #include <snappy.h>
-      int main() {}
-EOF
-    if [ "$?" = 0 ]; then
-        COMMON_FLAGS="$COMMON_FLAGS -DSNAPPY"
-        PLATFORM_LIBS="$PLATFORM_LIBS -lsnappy"
-    fi
-
     # Test whether tcmalloc is available
     $CXX $CXXFLAGS -x c++ - -o $CXXOUTPUT -ltcmalloc 2>/dev/null  <<EOF
       int main() {}


### PR DESCRIPTION
When snappy is installed, leveldb is pretty insistent about linking
against it.  Make real sure that we don't turn it on and clear out old
state when rebuilding.
